### PR TITLE
Fix/tos 681 The display text in the "Delete" Warning message popup is inappropriate in Test Case Details Page

### DIFF
--- a/ui/src/app/components/cases/test-case-details.component.ts
+++ b/ui/src/app/components/cases/test-case-details.component.ts
@@ -125,6 +125,7 @@ export class TestCaseDetailsComponent extends BaseComponent implements OnInit {
           item: 'test case',
           name: this.testCase.name,
           note: this.translate.instant('message.common.confirmation.test_data_des', {Item:'test case'}),
+          confirmation: permanently ? this.translate.instant("message.common.confirmation.note") : this.translate.instant("message.common.confirmation.note_trash"),
         },
         panelClass: ['matDialog', 'delete-confirm']
       });

--- a/ui/src/app/components/cases/test-case-details.component.ts
+++ b/ui/src/app/components/cases/test-case-details.component.ts
@@ -125,7 +125,6 @@ export class TestCaseDetailsComponent extends BaseComponent implements OnInit {
           item: 'test case',
           name: this.testCase.name,
           note: this.translate.instant('message.common.confirmation.test_data_des', {Item:'test case'}),
-          confirmation: permanently ? this.translate.instant("message.common.confirmation.note") : this.translate.instant("message.common.confirmation.note_trash"),
         },
         panelClass: ['matDialog', 'delete-confirm']
       });

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -104,6 +104,7 @@
   "message.common.confirmation.default_change": "Are you sure to change this?",
   "message.common.confirmation.title": "Delete Confirmation",
   "message.common.confirmation.note": "You cannot undo this action!",
+  "message.common.confirmation.note_trash": "You can always restore the deleted test cases back from Trash!",
   "message.common.createdDate": "Created Date",
   "message.common.updatedDate": "Updated Date",
   "message.common.clear": "Clear",

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -104,7 +104,6 @@
   "message.common.confirmation.default_change": "Are you sure to change this?",
   "message.common.confirmation.title": "Delete Confirmation",
   "message.common.confirmation.note": "You cannot undo this action!",
-  "message.common.confirmation.note_trash": "You can always restore the deleted test cases back from Trash!",
   "message.common.createdDate": "Created Date",
   "message.common.updatedDate": "Updated Date",
   "message.common.clear": "Clear",


### PR DESCRIPTION
Steps for reproduce

Create Test Case

Click on the delete icon in the Test case details page and observe 

Actual

The display text in the "Delete" Warning message popup is inappropriate in Test Case Details Page

Expected

The display text in the "Delete" Warning message popup to be displayed as same as it is displayed in cloud in the Test Case Details Page