### PR TITLE
T0S-683 Empty Element Blank Overlay Issue

### DIFF
--- a/ui/src/app/components/webcomponents/action-step-form.component.ts
+++ b/ui/src/app/components/webcomponents/action-step-form.component.ts
@@ -1283,18 +1283,19 @@ export class ActionStepFormComponent extends BaseComponent implements OnInit {
       if(!name && this.testStep?.addonElements && targetElement?.dataset?.reference){
         name = this.testStep.addonElements[targetElement.dataset.reference]?.name;
       }
-    }
-    return name;
+    };
+    return name !="element" ? name : undefined;
   }
 
   private getPreviousStepElement() {
     for (let i = this.testStep.position - 1; i >= 0; i--) {
       let elementName = this.testSteps.content?.[i]?.element;
-      if (elementName) {
+      if (elementName && elementName != "element") {
         return elementName;
       }
     }
   }
+
   private openElementsPopup(targetElement?) {
     let sendDetails = {
       version: this.version,


### PR DESCRIPTION
The element overlay is displayed as a blank screen when we edit the step and click on an empty element.