### PR TITLE
 TOS-730 The warning message for Uploads is inappropriate

### DIFF
--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -1766,7 +1766,7 @@
   "step.create.help.expert": "Get expert help for Test Case creation,",
   "step.create.help.expert_msg": "Chat with Us!",
   "td_nav.add_ons": "Addons",
-  "message.delete.uploads": "Please detach the upload with the below test plans, and try deleting.",
+  "message.delete.uploads": "This Upload is used in the below Test Devices, Please remove the mapping and try again.",
   "test_plan_form.machine-empty": "You now need to install the Testsigma Agent then select your {{LabelName}}",
   "test_plan_form.agents_info": "Click here to know more about this",
   "test_plan_form.install": "Install",


### PR DESCRIPTION
Actual

The warning message for Uploads is inappropriate i.e., it is displaying device names and stating as “Please detach the upload with the below test plans, and try deleting.“

Expected

The warning message to be displayed as “This Upload is used in the below Test Devices,
Please remove the mapping and try again.“