### PR TITLE
TOS-759 "IF Conditionl" steps are getting duplicated for only the last iteration in a "FOR Loop"

### DIFF
--- a/server/src/main/java/com/testsigma/service/AgentExecutionService.java
+++ b/server/src/main/java/com/testsigma/service/AgentExecutionService.java
@@ -1367,12 +1367,18 @@ public class AgentExecutionService {
                                                             String dataProfile, Map<Long, Integer> dataSetIndex) throws Exception {
 
     List<Long> loopIds = new ArrayList<>();
+    List<Long> skipIds = new ArrayList<>();
     List<TestCaseStepEntityDTO> toReturn = new ArrayList<>();
     for (TestStepDTO testStepDTO : testStepDTOS) {
 
       if (loopIds.contains(testStepDTO.getParentId())) {
+        skipIds.add(testStepDTO.getId());
+        continue;
+      } else if (skipIds.contains(testStepDTO.getParentId())) {
+        skipIds.add(testStepDTO.getId());
         continue;
       }
+
 
       if (testStepDTO.getType() == TestStepType.FOR_LOOP) {
         loopIds.add(testStepDTO.getId());


### PR DESCRIPTION
**FILE**
`server/src/main/java/com/testsigma/service/AgentExecutionService.java  =>getExecutableSteps()`

Generally we are skipping the step who's parent step type is LOOP 
If that step have more sub steps we are not skipping those steps and in the end they are getting duplicated in final execution

what I did here is add the step ID's whose parent step type is LOOP to a List called skipIds
now If a step parent ID is present in skipIds we'll add skip that step and also add that stepId to skipIDs
