### PR TITLE
When clicked on "Record" button for the Element Inspection , it displays "Loading" symbol continously

### DIFF
--- a/ui/src/app/components/elements/list.component.html
+++ b/ui/src/app/components/elements/list.component.html
@@ -187,7 +187,7 @@
       <div class="d-flex" *ngIf="filterId == 1 && !query">
         <button
           *ngIf="hasInspectorFeature()"
-          [routerLink]="['/agents', 'record', this.versionId]"
+          [routerLink]="['/td', 'record', this.versionId]"
           [queryParams]="{isRecord: true}"
           class="theme-btn-clear-default ml-14"
           [translate]="'elements.btn.record'"></button>


### PR DESCRIPTION
When clicked on "Record" button for the Element Inspection , it displays "Loading" symbol continously but doesn't start the Recorder  this occurs only for the Record button that is displayed at the bottom of the Empty Element List Page