### PR TITLE
Chrome Browser is being displayed Instead of Edge / Firefox browsers in the Test plan view reports page

### DIFF
--- a/ui/src/app/components/webcomponents/lab-environment-screen-short-info.component.ts
+++ b/ui/src/app/components/webcomponents/lab-environment-screen-short-info.component.ts
@@ -48,10 +48,10 @@ import {WorkspaceVersionService} from "../../shared/services/workspace-version.s
           <span
             *ngIf="!isMobile"
             class="mr-5 sm" style="height: 14px"
-            [class.chrome]="testDevice?.isChrome && testDevice?.formattedBrowserVersion"
-            [class.safari]="testDevice?.isSafari && testDevice?.formattedBrowserVersion"
-            [class.firefox]="testDevice?.isFirefox && testDevice?.formattedBrowserVersion"
-            [class.edge]="testDevice?.isEdge && testDevice?.formattedBrowserVersion"></span>
+            [class.chrome]="isChrome && testDevice?.formattedBrowserVersion"
+            [class.safari]="isSafari && testDevice?.formattedBrowserVersion"
+            [class.firefox]="isFirefox && testDevice?.formattedBrowserVersion"
+            [class.edge]="isEdge && testDevice?.formattedBrowserVersion"></span>
           <span class="pr-8"
                 *ngIf="!isMobile && testDevice?.formattedBrowserVersion"
                 [textContent]="testDevice?.formattedBrowserVersion"></span>
@@ -197,5 +197,36 @@ export class LabEnvironmentScreenShortInfoComponent implements OnInit {
     return this.testDevice?.version?.workspace?.isMobile;
   }
 
+  /**
+   * Returns a boolean value true when the browser environment is Google Chrome
+   * @returns boolean
+   */
+  get isChrome() {
+    return this.environmentResult.testDeviceSettings.isChrome
+  }
+
+  /**
+   * Returns a boolean value true when the browser environment is Mozilla Firefox
+   * @returns boolean
+   */
+  get isFirefox() {
+    return this.environmentResult.testDeviceSettings.isFirefox
+  }
+
+  /**
+   * Returns a boolean value true when the browser environment is Safari
+   * @returns boolean
+   */
+  get isSafari() {
+    return this.environmentResult.testDeviceSettings.isSafari
+  }
+
+  /**
+   * Returns a boolean value true when the browser environment is Microsoft Edge
+   * @returns boolean
+   */
+  get isEdge() {
+    return this.environmentResult.testDeviceSettings.isEdge
+  }
 
 }

--- a/ui/src/app/shared/components/webcomponents/test-machine-info-column.component.ts
+++ b/ui/src/app/shared/components/webcomponents/test-machine-info-column.component.ts
@@ -47,9 +47,9 @@ import {Platform} from "../../../enums/platform.enum";
         <i
           #osTooltip="matTooltip"
           *ngIf="isHybrid && !agentDevice"
-          [class.fa-windows-brands]="agent.isWindows"
-          [class.fa-apple]="agent.isMac"
-          [class.fa-linux-2]="agent.isLinux"
+          [class.fa-windows-brands]="isWindows"
+          [class.fa-apple]="isMac"
+          [class.fa-linux-2]="isLinux"
           [matTooltip]="isHybrid && agentDevice ? 'V. ' +agentDevice.osVersion : ( 'agents.list_view.os' | translate) +' : '+ testDevice?.platform+' '+testDevice?.formattedOsVersion"
         ></i>
         <i
@@ -184,7 +184,31 @@ export class TestMachineInfoColumnComponent implements OnInit {
   }
 
   get isHybrid() {
-    return this.testPlanResult?.testPlan?.isHybrid || this.testPlan?.isHybrid;
+    return this.testDevice.isHybrid;
+  }
+
+  /**
+   * Returns a boolean value true when the execution environment is Windows
+   * @returns boolean
+   */
+  get isWindows() {
+    return this.testDevice.isWindows
+  }
+
+  /**
+   * Returns a boolean value true when the execution environment is Mac OS
+   * @returns boolean
+   */
+  get isMac() {
+    return this.testDevice.isMac
+  }
+
+  /**
+   * Returns a boolean value true when the execution environment is Linux
+   * @returns boolean
+   */
+  get isLinux() {
+    return this.testDevice.isLinux
   }
 
   get isMobileWeb() {


### PR DESCRIPTION
Chrome Browser is being displayed Instead of Edge / Firefox browsers in the Test plan view reports page

## Description

> Fixed the issue now the reports are showing correct browser information in reports

## Fixes # (issue)

> Instead of retrieving information from test device, retrieving environment settings 

