### PR TITLE
fix(TestStep):"Conditional IF" step is displayed in wrong order when when we "add step"

### DIFF
--- a/ui/src/app/components/webcomponents/test-step-list-item.component.ts
+++ b/ui/src/app/components/webcomponents/test-step-list-item.component.ts
@@ -182,7 +182,7 @@ export abstract class TestStepListItemComponent extends BaseComponent implements
     this.isCloning = true;
     let testStepNew: TestStep = new TestStep().deserialize(testStep.serialize());
     testStepNew.id = undefined;
-    testStepNew.position = this.testSteps.totalElements+1;
+    testStepNew.position = this.testSteps.totalElements;
     testStepNew.copiedFrom = testStep.id;
     delete testStepNew.parentId;
     this.testStepService.create(testStepNew).subscribe((step) => {


### PR DESCRIPTION
TOS-365

## Description

Fixes the wrong steps order, when we try to add a Teststep from Add step while hovering on a step

## Issue

"Conditional IF" step is displayed in wrong order when we "add step" until the page is refreshed -->this occurs when cloned steps are present

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Changes would cause existing functionality to not work as expected
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


[TOS-365]: https://testsigma.atlassian.net/browse/TOS-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ