### PR TITLE
[TOS-659] fix (AgentService): OS version windows 11 version support added

### DIFF
--- a/agent/src/main/java/com/testsigma/agent/services/AgentService.java
+++ b/agent/src/main/java/com/testsigma/agent/services/AgentService.java
@@ -47,8 +47,10 @@ public class AgentService {
           osVersion = "8";
         } else if (osVersion.startsWith("6.3")) {
           osVersion = "8.1";
-        } else if (osVersion.startsWith("10.0")) {
+        } else if (osVersion.startsWith("10.0.1")) {
           osVersion = "10";
+        } else if (osVersion.startsWith("10.0.2")){
+          osVersion = "11";
         }
       } else if (SystemUtils.IS_OS_MAC_OSX) {
         if (osVersion.startsWith("10.16")) {


### PR DESCRIPTION
Jira Link: https://testsigma.atlassian.net/browse/TOS-659

Windows 10 version builds:
First Release : 10.0.10240
Last Release : 10.0.19045

Windows 11 version builds:
First Release : 10.0.22000
Latest Release : 10.0.22621

The fix will segregate Windows 10 machines and Windows 11 machines using their build numbers.

Reference Links:
https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
https://learn.microsoft.com/en-us/windows/release-health/release-information

[TOS-659]: https://testsigma.atlassian.net/browse/TOS-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ