### PR TITLE
[TOS-890] fix : Microsoft Edge version in Windows

### DIFF
--- a/agent/src/main/java/com/testsigma/agent/browsers/WindowsBrowsers.java
+++ b/agent/src/main/java/com/testsigma/agent/browsers/WindowsBrowsers.java
@@ -197,7 +197,7 @@ public class WindowsBrowsers {
     String version = NOT_FOUND;
     String edgeRegKey = searchRegistryByPattern(
       "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\",
-      ".*(Microsoft Edge.*)");
+      ".*(Microsoft Edge$)");
 
     if (StringUtils.isNotBlank(edgeRegKey)) {
       version = searchRegistryByPattern(
@@ -208,7 +208,7 @@ public class WindowsBrowsers {
     if (StringUtils.isBlank(version) || NOT_FOUND.equals(version)) {
       edgeRegKey = searchRegistryByPattern(
         "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\",
-        ".*(Microsoft Edge.*)");
+        ".*(Microsoft Edge$)");
 
       if (StringUtils.isNotBlank(edgeRegKey)) {
         version = searchRegistryByPattern(
@@ -220,9 +220,14 @@ public class WindowsBrowsers {
 
     if (StringUtils.isBlank(version) || NOT_FOUND.equals(version)) {
       String registryKey = "HKEY_CLASSES_ROOT\\Local Settings\\Software\\Microsoft\\Windows\\CurrentVersion\\AppModel\\PackageRepository\\Packages";
-      String regexPattern = ".*Microsoft.MicrosoftEdge_(.*)";
+      String regexPattern = ".*Microsoft.MicrosoftEdge.Stable_(.*)";
       String regValue = searchRegistryByPattern(registryKey, regexPattern);
       version = regValue.split("_")[0];
+      if(StringUtils.isBlank(version) || NOT_FOUND.equals(version)) {
+        regexPattern = ".*Microsoft.MicrosoftEdge_(.*)";
+        regValue = searchRegistryByPattern(registryKey, regexPattern);
+        version = regValue.split("_")[0];
+      }
     }
     if (version.equals(NOT_FOUND))
       version = getBrowserVersionFromExe("Microsoft\\Edge\\Application\\msedge.exe");


### PR DESCRIPTION
Jira Ticket: https://testsigma.atlassian.net/browse/TOS-890

Regex Expression  ".*(Microsoft Edge$)" will make sure that it will take values only which ends with Edge. Values with text after Edge will not be accepted.

In the registry entry,
"HKEY_CLASSES_ROOT\\Local Settings\\Software\\Microsoft\\Windows\\CurrentVersion\\AppModel\\PackageRepository\\Packages"
There exists 3 Microsoft Edge entries. 
1. Microsoft.MicrosoftEdge.Stable_108.0.1462.54
2. Microsoft.MicrosoftEdge_44.22621.819.0
3. Microsoft.MicrosoftEdge.DevToolsClient_1000.22621.1.0

We require the Stable entry as it specifies the correct browser version. 
So the regex expression is modified into: ".*Microsoft.MicrosoftEdge.Stable_(.*)"

If stable is not present then, it will take the Edge_ value.