### PR TITLE
[TOS-782]fix: Uploads Deletion

### DIFF
--- a/server/src/main/java/com/testsigma/controller/UploadsController.java
+++ b/server/src/main/java/com/testsigma/controller/UploadsController.java
@@ -81,9 +81,7 @@ public class UploadsController {
 
   @DeleteMapping(value = "/bulk")
   @ResponseStatus(HttpStatus.ACCEPTED)
-  public void bulkDelete(@RequestParam(value = "ids[]") Long[] ids) throws ResourceNotFoundException {
-    for (Long id : ids) {
-      uploadService.delete(uploadService.find(id));
-    }
+  public void bulkDelete(@RequestParam(value = "ids[]") Long[] ids,@RequestParam(value = "workspaceVersionId") Long workspaceVersionId) throws Exception {
+      uploadService.bulkDelete(ids, workspaceVersionId);
   }
 }

--- a/server/src/main/java/com/testsigma/repository/UploadVersionRepository.java
+++ b/server/src/main/java/com/testsigma/repository/UploadVersionRepository.java
@@ -23,6 +23,7 @@ public interface UploadVersionRepository extends BaseRepository<UploadVersion, L
   List<UploadVersion> findAllByLastUploadedTimeBeforeAndUploadTypeIn(Timestamp lastUploadedTime, Collection<UploadType> uploadType);
 
   List<UploadVersion> findAllByUploadTypeIn(Collection<UploadType> uploadType);
+  List<UploadVersion> findAllByUploadId(Long uploadId);
 
 
   Optional<UploadVersion> findByNameAndUploadId(String name, Long importedId);

--- a/server/src/main/java/com/testsigma/service/UploadService.java
+++ b/server/src/main/java/com/testsigma/service/UploadService.java
@@ -22,11 +22,13 @@ import com.testsigma.model.*;
 import com.testsigma.repository.UploadRepository;
 import com.testsigma.specification.SearchCriteria;
 import com.testsigma.specification.SearchOperation;
+import com.testsigma.specification.TestCaseSpecificationsBuilder;
 import com.testsigma.specification.UploadSpecificationsBuilder;
 import com.testsigma.web.request.UploadRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -50,6 +52,7 @@ public class UploadService extends XMLExportImportService<Upload> {
   private final WorkspaceService workspaceService;
   private final WorkspaceVersionService workspaceVersionService;
   private final UploadVersionService uploadVersionService;
+  private final TestCaseService testCaseService;
   private final UploadMapper mapper;
 
   public Upload find(Long id) throws ResourceNotFoundException {
@@ -114,6 +117,32 @@ public class UploadService extends XMLExportImportService<Upload> {
   public void delete(Upload upload) {
     this.uploadRepository.delete(upload);
     publishEvent(upload, EventType.DELETE);
+  }
+  public void bulkDelete(Long[] ids, Long workspaceVersionId) throws Exception {
+    Boolean allIdsDeleted = true;
+    TestCaseSpecificationsBuilder builder = new TestCaseSpecificationsBuilder();
+    for (Long id : ids) {
+      List<SearchCriteria> params = new ArrayList<>();
+      List<UploadVersion> uploadVersions = uploadVersionService.findByUploadId(id);
+      //TODO below check in for(uploadVersions)
+      for(UploadVersion uploadVersion: uploadVersions ) {
+        params.add(new SearchCriteria("testData", SearchOperation.EQUALITY, "testsigma-storage:/"+uploadVersion.getPath()));
+        params.add(new SearchCriteria("workspaceVersionId", SearchOperation.EQUALITY, workspaceVersionId));
+        builder.setParams(params);
+        Specification<TestCase> spec = builder.build();
+        Page<TestCase> linkedTestCases = testCaseService.findAll(spec, PageRequest.of(0, 1));
+        if(linkedTestCases.getTotalElements() > 0){
+          allIdsDeleted = false;
+          break;
+        }
+        Upload upload = find(id);
+        this.delete(upload);
+        }
+    }
+    if (!allIdsDeleted) {
+      throw new DataIntegrityViolationException("dataIntegrityViolationException: Failed to delete some of the Uploads " +
+              "since they are already associated to some Test Cases.");
+    }
   }
 
   public void publishEvent(Upload upload, EventType eventType) {

--- a/server/src/main/java/com/testsigma/service/UploadVersionService.java
+++ b/server/src/main/java/com/testsigma/service/UploadVersionService.java
@@ -356,4 +356,7 @@ public class UploadVersionService extends XMLExportImportService<UploadVersion> 
   }
 
 
+  public List<UploadVersion> findByUploadId(Long id) {
+    return uploadVersionRepository.findAllByUploadId(id);
+  }
 }

--- a/server/src/main/java/com/testsigma/specification/TestCaseSpecification.java
+++ b/server/src/main/java/com/testsigma/specification/TestCaseSpecification.java
@@ -92,6 +92,9 @@ public class TestCaseSpecification extends BaseSpecification<TestCase> {
     } else if(criteria.getKey().equals("forLoopTestDataId")){
       Join s = root.join("testSteps",JoinType.INNER);
       return s.get("forLoopTestDataId");
+    } else if(criteria.getKey().equals("testData")){
+      Join s = root.join("testSteps", JoinType.INNER);
+      return s.get("testData");
     }
     return root.get(criteria.getKey());
   }

--- a/ui/src/app/components/uploads/list.component.html
+++ b/ui/src/app/components/uploads/list.component.html
@@ -8,7 +8,7 @@
 
   <div class="d-flex align-items-center ml-auto"
        *ngIf="selectedUploads.length">
-    <button (click)="checkForLinkedEnvironments(null)"
+    <button (click)="openDeleteDialog()"
             [matTooltip]="'hint.message.common.delete_selected' | translate"
             class="btn icon-btn border-rds-2 ml-14"
             *ngIf="selectedUploads.length">
@@ -97,7 +97,7 @@
               (click)="openSaveUploadForm(upload)"
               class="fa-pencil-on-paper action-icon"></a>
             <a
-              data-placement="bottom" (click)="checkForLinkedEnvironments(upload.id, upload.name)"
+              data-placement="bottom" (click)="checkForLinkedEntities(upload.id, upload.name)"
               [matTooltip]="'pagination.delete' | translate"
               href="javascript:void(0)"
               class="fa-trash-thin action-icon"></a>

--- a/ui/src/app/components/uploads/list.component.ts
+++ b/ui/src/app/components/uploads/list.component.ts
@@ -22,6 +22,8 @@ import {UploadEntitiesModalComponent} from "../../shared/components/webcomponent
 import {TestDeviceService} from "../../services/test-device.service";
 import {ToastrService} from "ngx-toastr";
 import {UploadVersionService} from "../../shared/services/upload-version.service";
+import {TestCaseService} from "../../services/test-case.service";
+import {LinkedEntitiesModalComponent} from "../../shared/components/webcomponents/linked-entities-modal.component";
 
 @Component({
   selector: 'app-uploads',
@@ -57,6 +59,9 @@ export class ListComponent extends BaseComponent implements OnInit {
     private workspaceVersionService: WorkspaceVersionService,
     private _snackBar: MatSnackBar,
     private _appOverlayContainer: OverlayContainer,
+
+    private testCaseService :TestCaseService,
+
     public environmentService: TestDeviceService) {
     super(authGuard, notificationsService, translate, toastrService);
   }
@@ -141,6 +146,45 @@ export class ListComponent extends BaseComponent implements OnInit {
     }
   }
 
+  checkForLinkedTestCases(testData?,id?) {
+    let testCases: InfiniteScrollableDataSource;
+    let query = "workspaceVersionId:" + this.versionId + ",testData:" + encodeURI(testData?.join("#"))
+    query = this.byPassSpecialCharacters(query);
+    testCases = new InfiniteScrollableDataSource(this.testCaseService,query);
+
+    waitTillRequestResponds();
+    let _this = this;
+
+    function waitTillRequestResponds() {
+      if (testCases.isFetching)
+        setTimeout(() => waitTillRequestResponds(), 100);
+      else {
+        if (testCases.isEmpty)
+          _this.openDeleteDialog(id);
+        else
+          _this.openLinkedTestCasesDialog(testCases);
+      }
+    }
+  }
+  private openLinkedTestCasesDialog(list) {
+    this.translate.get("uploads.linked.with.test_cases").subscribe((res) => {
+      this.matDialog.open(LinkedEntitiesModalComponent, {
+        width: '568px',
+        height: 'auto',
+        data: {
+          description: res,
+          linkedEntityList: list,
+        },
+        panelClass: ['mat-dialog', 'rds-none']
+      });
+    });
+  }
+
+
+
+  checkForLinkedEntities(id, name?: string) {
+    this.checkForLinkedEnvironments(id, name);
+  }
   checkForLinkedEnvironments(id, name?: string) {
     let environmentResults: InfiniteScrollableDataSource;
     environmentResults = new InfiniteScrollableDataSource(this.environmentService, "appUploadId@"+(id ? id : this.selectedUploads.join("#"))+",entityType:TEST_PLAN");
@@ -152,7 +196,10 @@ export class ListComponent extends BaseComponent implements OnInit {
         setTimeout(() => waitTillRequestResponds(environmentResults, id, name), 100);
       else {
         if (environmentResults.isEmpty)
-          _this.openDeleteDialog(id, name);
+          _this.uploadVersionService.findAll("uploadId:" + id).subscribe(res => {
+            let uploadPaths = res.content.map(version =>"testsigma-storage:/" + version.path)
+            _this.checkForLinkedTestCases(uploadPaths,id);
+          })
         else
           _this.openLinkedUploadsDialog(environmentResults);
       }
@@ -240,8 +287,7 @@ export class ListComponent extends BaseComponent implements OnInit {
   private destroyUpload(id: any) {
     this.uploadService.destroy(id).subscribe(
       () => {
-        this.translate.get('message.common.deleted.success', {FieldName: "Upload"})
-          .subscribe(res => this.showNotification(NotificationType.Success, res));
+        this.translate.get('message.common.deleted.success', {FieldName: "Upload"}).subscribe(res => this.showNotification(NotificationType.Success, res));
         this.fetchUploads();
         this.selectedUploads = [];
       },
@@ -251,13 +297,13 @@ export class ListComponent extends BaseComponent implements OnInit {
   }
 
   private multipleDelete() {
-    this.uploadService.bulkDestroy(this.selectedUploads).subscribe(
+    this.uploadService.bulkDestroy(this.selectedUploads, this.versionId).subscribe(
       () => {
         this.translate.get("message.common.deleted.success", {FieldName: "Uploads"}).subscribe(res => this.showNotification(NotificationType.Success, res));
         this.fetchUploads();
         this.selectedUploads = []
       },
-      (err) => this.translate.get("message.common.deleted.failure", {FieldName: "Uploads"}).subscribe(res => this.showAPIError(NotificationType.Error, res,"Uploads","Test Case")))
+      (err) => this.translate.get("message.common.uploads.deleted.failure", {FieldName: "Uploads"}).subscribe(res => this.showAPIError(NotificationType.Error, res,"Uploads","Test Case")))
   }
 
   private goToPreviousPageIfEmpty(res) {

--- a/ui/src/app/shared/services/upload.service.ts
+++ b/ui/src/app/shared/services/upload.service.ts
@@ -46,8 +46,8 @@ export class UploadService {
     );
   }
 
-  public bulkDestroy(ids: number[]): Observable<void> {
-    let params = new HttpParams().set("ids[]", ids.toString());
+  public bulkDestroy(ids: number[], workspaceVersionId: number ): Observable<void> {
+    let params = new HttpParams().set("ids[]", ids.toString()).set("workspaceVersionId", workspaceVersionId);
     return this.http.delete<void>(this.URLConstants.uploadsUrl + "/bulk", {
       headers: this.httpHeaders.contentTypeApplication,
       params: params

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -1386,6 +1386,7 @@
   "uploads.list.message.copied": "Copied!",
   "uploads.list.copy_path": "Copy Path",
   "uploads.bulk_delete.confirmation.message": "Are you sure you want to delete the selected ( {{FieldName}} ) Uploads?",
+  "uploads.linked.with.test_cases": "This Upload is used in the below Test Cases,Please remove the mapping and try again",
   "uploads.form.create_title": "Upload",
   "uploads.form.edit_title": "Update File",
   "uploads.form.label.select_file_type": "Select Type",
@@ -2139,5 +2140,6 @@
   "hint.xray.assets": "Enable Jira Integration to publish the logs, screenshots & videos in execution result.",
   "xray.filter.title": "Added Xray Id",
   "err.empty_elements": "Error While fetching empty elements",
-  "err.url_validation": "Error while validating testdata url"
+  "err.url_validation": "Error while validating testdata url",
+  "message.common.uploads.deleted.failure": "Failed to delete some of the Uploads since they are already associated to some Test Cases."
 }


### PR DESCRIPTION
Jira Ticket : https://testsigma.atlassian.net/browse/TOS-782

Problem Statement: 
Uploads are being deleted even though they are being used in existing Test Cases / Test Machines.
The issue exists in both Bulk update and Single Upload deletion scenarios.

Solution:

**Single Upload Deletion:**

-  When Upload is selected for deletion but is used in certain Test Cases / Test Machines, display a dialog with the list of test cases the upload is linked to, along with the redirection to the test case. 
-  When the upload is not used in any test case/ test machine, display the confirmation for deletion and display the deletion success notification.

**Bulk Upload Deletion:**

-  While multiple uploads are selected for deletion and some of the uploads are linked to any Test Cases/ Test Machines, display the deletion failure message and prompt the user to remove any related mappings associated with the upload.
-  When the selected uploads are not associated with any Test Cases/ Test Machines, delete the selected uploads and display the deletion successful notification.


