### PR TITLE
[TOS-669] fix : Checking ipa architecture and ios emulator/real-device

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -28,7 +28,7 @@ server.forward-headers-strategy=framework
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST_NAME:localhost}:${MYSQL_PORT:3306}/${MYSQL_DB_NAME:testsigma_opensource}?allowPublicKeyRetrieval=true&useSSL=false
 spring.datasource.username=${MYSQL_USER:root}
-spring.datasource.password=${MYSQL_PASSWORD:root}
+spring.datasource.password=${MYSQL_PASSWORD:Password123#@!}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.properties.hibernate.metadata_builder_contributor=com.testsigma.hibernate.query.function.SqlFunctionsMetadataBuilderContributor

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -28,7 +28,7 @@ server.forward-headers-strategy=framework
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST_NAME:localhost}:${MYSQL_PORT:3306}/${MYSQL_DB_NAME:testsigma_opensource}?allowPublicKeyRetrieval=true&useSSL=false
 spring.datasource.username=${MYSQL_USER:root}
-spring.datasource.password=${MYSQL_PASSWORD:Password123#@!}
+spring.datasource.password=${MYSQL_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.properties.hibernate.metadata_builder_contributor=com.testsigma.hibernate.query.function.SqlFunctionsMetadataBuilderContributor

--- a/ui/src/app/agents/enums/supported-device-type.ts
+++ b/ui/src/app/agents/enums/supported-device-type.ts
@@ -1,4 +1,5 @@
 export enum SupportedDeviceType {
   IOS_DEVICE = "IOS_DEVICE",
-  IOS_EMULATOR = "IOS_EMULATOR"
+  IOS_EMULATOR = "IOS_EMULATOR",
+  NULL = "NULL"
 }

--- a/ui/src/app/shared/components/webcomponents/inspection-modal.component.ts
+++ b/ui/src/app/shared/components/webcomponents/inspection-modal.component.ts
@@ -15,7 +15,7 @@ import {MobileOsVersionService} from "../../../agents/services/mobile-os-version
 import {CloudDevice} from "../../../agents/models/cloud-device.model";
 import {AuthenticationGuard} from "../../guards/authentication.guard";
 import {BaseComponent} from "../base.component";
-import {NotificationsService} from 'angular2-notifications';
+import {NotificationsService, NotificationType} from 'angular2-notifications';
 import {TranslateService} from '@ngx-translate/core';
 import {ToastrService} from "ngx-toastr";
 import {MobileOsType} from "../../../agents/enums/mobile-os-type.enum";
@@ -24,9 +24,9 @@ import {PlatformService} from "../../../agents/services/platform.service";
 import {PlatformOsVersion} from "../../../agents/models/platform-os-version.model";
 import {Platform} from "../../../agents/models/platform.model";
 import {Pageable} from "../../models/pageable";
-import {UploadType} from "../../enums/upload-type.enum";
 import {ActivatedRoute, Params} from "@angular/router";
 import {MobileInspectionComponent} from "../../../agents/components/webcomponents/mobile-inspection.component";
+import {SupportedDeviceType} from "../../../agents/enums/supported-device-type";
 
 @Component({
   selector: 'app-inspection-modal',
@@ -241,6 +241,10 @@ export class InspectionModalComponent extends BaseComponent implements OnInit {
   }
 
   launch() {
+    if(!this.checkUploadCompatability()){
+      this.showNotification(NotificationType.Error, this.translate.instant("mobile_recorder.message.ipa.error"))
+      return;
+    }
     this.data.uiId = this.uiId;
     this.data.agent = this.agent;
     this.data.uploadId = this.uploadSelectionForm.getRawValue().app_upload_id;
@@ -413,5 +417,11 @@ export class InspectionModalComponent extends BaseComponent implements OnInit {
 
   isTestStep(){
     return this.isStepGroup;
+  }
+
+  private checkUploadCompatability() {
+    if(!this.isIOS) return true;
+    let device = this.devices?.content?.find(device => this.deviceId == device.id);
+    return (device?.isEmulator && this.upload.supportedDeviceType == SupportedDeviceType.IOS_EMULATOR) ||  (!device?.isEmulator && this.upload.supportedDeviceType == SupportedDeviceType.IOS_DEVICE);
   }
 }

--- a/ui/src/app/shared/components/webcomponents/uploads-form.component.ts
+++ b/ui/src/app/shared/components/webcomponents/uploads-form.component.ts
@@ -181,6 +181,6 @@ export class UploadsFormComponent extends BaseComponent implements OnInit {
   }
   get isButtonDisabled() {
     return (this.upload.id ? (!this.getRawValue()?.name || this.uploadForm.controls?.name?.errors ||
-    this.uploadedFileObject?.name ? this.uploadForm.invalid : false) : this.uploadForm.invalid) || !this.upload.name || this.maxSizeError;
+    this.uploadedFileObject?.name ? this.uploadForm.invalid : false) : this.uploadForm.invalid) || !this.upload.name || this.maxSizeError || this.upload.supportedDeviceType==this.SupportedDeviceType.NULL;
   }
 }

--- a/ui/src/app/shared/models/upload.model.ts
+++ b/ui/src/app/shared/models/upload.model.ts
@@ -12,7 +12,7 @@ export class Upload extends Base implements PageObject {
   public latestVersionId: number;
 
   @serializable(optional())
-  public supportedDeviceType: SupportedDeviceType = SupportedDeviceType.IOS_DEVICE;
+  public supportedDeviceType: SupportedDeviceType = SupportedDeviceType.NULL;
 
   public selected: Boolean;
   public filePathCopied: boolean;

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -674,6 +674,7 @@
   "mobile_recorder.message.preparing": "<span class=\"text-center\"> Please wait <br>while the Testsigma Mobile Inspector finishes loading <span class=\"loading-dots\"></span></span>",
   "mobile_recorder.message.refresh": "Loading. Please wait...",
   "mobile_recorder.message.error": "Error, please contact support",
+  "mobile_recorder.message.ipa.error": "Select iOS ipa file type based on execution on simulator or real device",
   "mobile_recorder.message.incompatible.error": "Incompatible app and device architecture",
   "mobile_recorder.notification.start.failure_troubleshoot": "Mobile inspector Failed to Load, please <a href='https://testsigma.com/docs/troubleshooting/mobile-apps/failed-to-launch-test-recorder/' target='_blank'>Click Here</a> to access the Trouble Shooting guide to understand how to fix this",
   "mobile_recorder.notification.action.failure_troubleshoot": "Failed to Perform the {{actionType}} action, please <a href='https://testsigma.com/docs/troubleshooting/mobile-apps/mobile-recorder-actions-failures/{{guideLink}}' target='_blank'>Click Here</a> to access the Trouble Shooting guide to understand how to fix this",


### PR DESCRIPTION
Jira Ticket: https://testsigma.atlassian.net/browse/TOS-669
There is no any appropriate error message displayed in Mobile inspector when we use an Emulator ipa to record steps using Real Device

Steps for reproduce

Enable any storage
Upload an emulator app
Connect a Real Device
Create Test Case
Click on Record button within the Test Case
Select Real Device as the Device
select emulator ipa as the upload
Click on Record button
Wait until the app is uploaded and observe the Error message

Actual

There is no any appropriate error message displayed in Mobile inspector when we use an Emulator IPA to record steps using Real Device

Expected

There should be an appropriate error message displayed in Mobile inspector when we use an Emulator IPA to record steps using Real Device

Fix:
Have added a condition to check the app architecture and ios device type and if they are same, then the recorder is launched, else error message is displayed as notification.
Have added a null value to supportedDeviceType so that no value is selected by default in uploads page.
Have added a condition to the upload button as supportedDevicetyper should not be null, thus making it a mandatory field for the user.