### PR TITLE
[TOS-958] fix: Rerun status alignment fixed

### DIFF
--- a/ui/src/app/components/webcomponents/result-status-label-info.component.ts
+++ b/ui/src/app/components/webcomponents/result-status-label-info.component.ts
@@ -7,8 +7,7 @@ import {TestDeviceResult} from "../../models/test-device-result.model";
   selector: 'app-result-status-label-info',
   template: `
     <app-re-run-icon class="fz-18 mt-2 position-absolute" [resultEntity]="resultEntity"></app-re-run-icon>
-    <div class="mr-5 px-10"
-         [class.ml-25]="resultEntity?.childResult"
+    <div class="mr-5 px-10 ml-25"
          [class.running]="resultEntity?.isRunning"
          [class.passed]="resultEntity?.isPassed"
          [class.stopped]="resultEntity?.isStopped"


### PR DESCRIPTION
Jira Ticket: https://testsigma.atlassian.net/browse/TOS-958

Rerun status alignment looking not good

![image](https://user-images.githubusercontent.com/106724526/211763679-972c0377-c762-496c-8ae1-a3698a8338df.png)
![image](https://user-images.githubusercontent.com/106724526/211763729-da00cf00-4b68-4f57-a683-61361196003f.png)

This occurs for all types of case scenarios, running, stopped, failed, etc

ml-25 was added to the tag irrespective of childResult. This fixes the problem. 
ml-25 was initially kept only for childResult but not its kept globally. So all classes will have the attribute ml-25