### PR TITLE
[TOS-963] fix: Test-data in addons is modified in action text

### DIFF
--- a/ui/src/app/services/test-step.service.ts
+++ b/ui/src/app/services/test-step.service.ts
@@ -63,6 +63,10 @@ export class TestStepService {
   }
 
   public create(step: TestStep): Observable<TestStep> {
+    step.addonTemplate.parameters.filter(a=> a.allowedValues.length==0).forEach(p=>{
+      let temp = p.reference;
+      step.action = step.action.replace(temp, step.addonTestData[temp].value);
+    });
     return this.http.post<TestStep>(this.URLConstants.testStepsUlr, step.serialize(), {
       headers: this.httpHeaders.contentTypeApplication
     }).pipe(

--- a/ui/src/app/services/test-step.service.ts
+++ b/ui/src/app/services/test-step.service.ts
@@ -63,10 +63,11 @@ export class TestStepService {
   }
 
   public create(step: TestStep): Observable<TestStep> {
+    if (step.addonTestData){
     step.addonTemplate.parameters.filter(a=> a.allowedValues.length==0).forEach(p=>{
       let temp = p.reference;
       step.action = step.action.replace(temp, step.addonTestData[temp].value);
-    });
+    });}
     return this.http.post<TestStep>(this.URLConstants.testStepsUlr, step.serialize(), {
       headers: this.httpHeaders.contentTypeApplication
     }).pipe(


### PR DESCRIPTION
Jira Ticket: https://testsigma.atlassian.net/browse/TOS-963
Github Issue: https://github.com/testsigmahq/testsigma/issues/267

Issue: The test-data value present in the addon is changed the defaukt action text value when recorder is clicked.
![image](https://user-images.githubusercontent.com/106724526/211974400-c8bcf309-1897-44d0-84bd-8cb811963d20.png)
![image](https://user-images.githubusercontent.com/106724526/211974425-55f97dcf-8e36-4aa3-8ac7-c3e6f4a2aa71.png)

Fix: The test-data value is now updated in the action text thus fixing the issue