### PR TITLE
[TOS-990] fix(test-case-details): removing step groups from test cases upon deletion

### DIFF
--- a/ui/src/app/components/cases/test-case-details.component.ts
+++ b/ui/src/app/components/cases/test-case-details.component.ts
@@ -146,25 +146,47 @@ export class TestCaseDetailsComponent extends BaseComponent implements OnInit {
   }
 
   markAsDeleted() {
-    let fieldName = this.testCase.isStepGroup ? 'Step Group' : 'Test Case';
-    this.testCaseService.markAsDeleted(this.testCaseId).subscribe({
+    this.testCase.isStepGroup ? this.markGroupAsDeleted():this.markCaseAsDeleted();
+  }
+
+  markGroupAsDeleted(){
+    let ids: number[] = [this.testCaseId];
+    this.testCaseService.bulkMarkAsDeleted(ids).subscribe({
         next: () => {
-          this.fetchTestCase();
-          this.translate.get("message.common.deleted.success", {FieldName: this.testCaseName }).subscribe((res: string) => {
-            this.showNotification(NotificationType.Success, res);
-          });
+          this.deletionSuccessNotification();
         },
         error: (error) => {
-          if (error.status == "400") {
-            this.showNotification(NotificationType.Error, error.error);
-          } else {
-            this.translate.get("message.common.deleted.failure", {FieldName: this.testCaseName }).subscribe((res: string) => {
-              this.showNotification(NotificationType.Error, res);
-            });
-          }
+          this.deletionFailureNotification(error);
         }
       }
     );
+  }
+
+  markCaseAsDeleted(){    this.testCaseService.markAsDeleted(this.testCaseId).subscribe({
+        next: () => {
+          this.deletionSuccessNotification();
+        },
+        error: (error) => {
+          this.deletionFailureNotification(error);
+        }
+      }
+    );
+  }
+  deletionSuccessNotification(){
+    this.fetchTestCase();
+    this.translate.get("message.common.deleted.success", {FieldName: this.testCaseName }).subscribe((res: string) => {
+      this.showNotification(NotificationType.Success, res);
+    });
+  }
+
+  deletionFailureNotification(error){
+    if (error.status == "400") {
+      this.showNotification(NotificationType.Error, error.error);
+    } else {
+      this.translate.get("message.common.deleted.failure", {FieldName: this.testCaseName }).subscribe((res: string) => {
+        this.showNotification(NotificationType.Error, res);
+      });
+    }
   }
 
   openDetails() {


### PR DESCRIPTION
Jira: https://testsigma.atlassian.net/browse/TOS-990 child issue
Parent issue: https://testsigma.atlassian.net/browse/TOS-789

Step groups are not getting deleted from its respective Test case when we try deleting it from Step Group Details page

Actual
It's not deleting until we delete it permanently

Expected
It should be deleted once we click on I understand, delete this Step group option

Fix
added the functionality to the delete button inside the step groups details page which was already present outside as a delete icon in the step groups list page.