### PR TITLE
[TOS-991] fix(test-case-details): test case list is displayed under step group

### DIFF
--- a/ui/src/app/components/cases/test-case-details.component.ts
+++ b/ui/src/app/components/cases/test-case-details.component.ts
@@ -26,6 +26,7 @@ import {EntityExternalMapping} from "../../models/entity-external-mapping.model"
 import {EntityExternalMappingService} from "../../services/entity-external-mapping.service";
 import {EntityType} from "../../enums/entity-type.enum";
 import {XrayKeyWarningComponent} from "../../agents/components/webcomponents/xray-key-warning-component";
+import {StepGroupFilterService} from "../../services/step-group-filter.service"
 
 @Component({
   selector: 'app-test-case-details',
@@ -61,6 +62,7 @@ export class TestCaseDetailsComponent extends BaseComponent implements OnInit {
     private userPreferenceService: UserPreferenceService,
     private chromeRecorderService : ChromeRecorderService,
     public entityExternalMappingService : EntityExternalMappingService,
+    public stepGroupFilterService: StepGroupFilterService,
   ) {
     super(authGuard, notificationsService, translate,toastrService);
   }
@@ -212,8 +214,21 @@ export class TestCaseDetailsComponent extends BaseComponent implements OnInit {
 
   deletePermanently() {
     this.testCaseService.destroy(this.testCaseId).subscribe({ next : () => {
-      this.router.navigate(['/td', this.testCase.workspaceVersionId, this.testCase?.testcaseRedirection, 'filter', this.userPreference?.testCaseFilterId]);
-    },
+        let redirect: any[] = ['/td', this.testCase?.workspaceVersionId, this.testCase?.testcaseRedirection];
+        if(this.testCase.isStepGroup && this.userPreference?.testCaseFilterId) {
+          this.stepGroupFilterService.show(this.userPreference?.testCaseFilterId).subscribe(res =>{
+              redirect = [...redirect, 'filter', this.userPreference?.testCaseFilterId]
+              this.router.navigate(redirect);
+            },
+            err => {
+              this.router.navigate(redirect);
+            }
+          )
+        }
+        else {
+          redirect = [...redirect, 'filter', this.userPreference?.testCaseFilterId]
+          this.router.navigate(redirect);
+        }    },
 
     error: (error) => {
           this.showNotification(NotificationType.Error, error && error.error && error.error.error ? error.error.error :


### PR DESCRIPTION
Jira: https://testsigma.atlassian.net/browse/TOS-991
Parent issue: https://testsigma.atlassian.net/browse/TOS-789

Actual
Test cases list displaying under step group list when we delete step group permanently
Once we refresh its displaying correctly

Expected
It should not show the test case list under the step group list

Fix
redirecting to the step group list page after permanently deleting stepgroup using step group filter service. 