### PR TITLE
[TOS-659] fix(AgentService) : support for windows 11 with OS_NAME

### DIFF
--- a/agent/src/main/java/com/testsigma/agent/services/AgentService.java
+++ b/agent/src/main/java/com/testsigma/agent/services/AgentService.java
@@ -47,8 +47,10 @@ public class AgentService {
           osVersion = "8";
         } else if (osVersion.startsWith("6.3")) {
           osVersion = "8.1";
-        } else if (osVersion.startsWith("10.0")) {
+        } else if (osVersion.startsWith("10.0.1")) {
           osVersion = "10";
+        } else if (osVersion.startsWith("10.0.2")){
+          osVersion = "11";
         }
       } else if (SystemUtils.IS_OS_MAC_OSX) {
         if (osVersion.startsWith("10.16")) {

--- a/agent/src/main/java/com/testsigma/agent/services/AgentService.java
+++ b/agent/src/main/java/com/testsigma/agent/services/AgentService.java
@@ -47,10 +47,12 @@ public class AgentService {
           osVersion = "8";
         } else if (osVersion.startsWith("6.3")) {
           osVersion = "8.1";
-        } else if (osVersion.startsWith("10.0.1")) {
-          osVersion = "10";
-        } else if (osVersion.startsWith("10.0.2")){
-          osVersion = "11";
+        } else if (osVersion.startsWith("10.0")) {
+          if(SystemUtils.OS_NAME.startsWith("Windows 11")) {
+            osVersion = "11";
+          } else {
+            osVersion = "10";
+          }
         }
       } else if (SystemUtils.IS_OS_MAC_OSX) {
         if (osVersion.startsWith("10.16")) {


### PR DESCRIPTION
Jira: https://testsigma.atlassian.net/browse/TOS-659

Actual
OS version is displayed as windows v10 instead of v11 in Adhoc Run page of Local device and Agents List Page

Expected
OS version to be displayed as windows v11 in Adhoc Run page of Local device and Agents List Page

Fix
Added a condition to check the os_name and display the respective version number. instead of checking build number, we now check os name startsWith.