### PR TITLE
[TOS-669] fix: changed error message for fail session creation

### DIFF
--- a/ui/src/app/agents/components/webcomponents/mobile-recording.component.ts
+++ b/ui/src/app/agents/components/webcomponents/mobile-recording.component.ts
@@ -215,7 +215,7 @@ export class MobileRecordingComponent extends BaseComponent implements OnInit {
           this.mobileSessionId = null;
         }
         console.log("Error while creating the session - ", error);
-        this.showNotification(NotificationType.Error, this.translate.instant("mobile_recorder.message.error"));
+        this.showNotification(NotificationType.Error, this.translate.instant("mobile_recorder.message.session.error"));
         this.loadingActions = false;
         this.loading = false;
       }

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -675,6 +675,7 @@
   "mobile_recorder.message.preparing": "<span class=\"text-center\"> Please wait <br>while the Testsigma Mobile Inspector finishes loading <span class=\"loading-dots\"></span></span>",
   "mobile_recorder.message.refresh": "Loading. Please wait...",
   "mobile_recorder.message.error": "Error, please contact support",
+  "mobile_recorder.message.session.error": "Error while creating mobile inspector session",
   "mobile_recorder.message.ipa.error": "Select iOS ipa file type based on execution on simulator or real device",
   "mobile_recorder.message.incompatible.error": "Incompatible app and device architecture",
   "mobile_recorder.notification.start.failure_troubleshoot": "Mobile inspector Failed to Load, please <a href='https://testsigma.com/docs/troubleshooting/mobile-apps/failed-to-launch-test-recorder/' target='_blank'>Click Here</a> to access the Trouble Shooting guide to understand how to fix this",


### PR DESCRIPTION
* Jira : https://testsigma.atlassian.net/browse/TOS-669
# Description
There is no any appropriate error message displayed in Mobile inspector when we use an Emulator ipa to record steps using Real Device

# Fix
changed the error message as the possible error returning from mobile inspector inside create session is 
* Error while creating the session - console
* Unable to create a new remote session - agent

So changed Error message to **Error while creating mobile inspector session**