### PR TITLE
Fix[TOS-966] : Test Plan Descriptions collapsed in run results window.

### DIFF
--- a/ui/src/app/components/results/list.component.html
+++ b/ui/src/app/components/results/list.component.html
@@ -89,7 +89,7 @@
             [textContent]="testPlan.name"></a>
           <div
             class="pt-4 text-t-secondary"
-            [matTooltip]="(testPlan?.description?.length>151) ? testPlan?.description : ''"
+            [matTooltip]="(testPlan?.description?.length>151) ? removeHtmlTags(testPlan?.description) : ''"
             [innerHTML]="(testPlan?.description?.length>151) ?
             (testPlan?.description | slice:0:150)+'...':(testPlan?.description) ||
               ('results.list_view.no_description' | translate) "></div>

--- a/ui/src/app/components/results/list.component.ts
+++ b/ui/src/app/components/results/list.component.ts
@@ -200,6 +200,9 @@ export class ResultsListComponent extends BaseComponent implements OnInit {
         this.discard();
     });
   }
+  removeHtmlTags(str) {
+    return str.replace(/<[^>]*>/g, '');
+  }
 
   discard() {
     this.query = undefined;


### PR DESCRIPTION
JIra: https://testsigma.atlassian.net/browse/TOS-966

Removed the HTML tags by adding a remove tags function which returns the string without the tags and rendered it.