### PR TITLE
feat(action-step-form): making one api call when while loop is created

### DIFF
--- a/server/src/main/java/com/testsigma/service/TestStepService.java
+++ b/server/src/main/java/com/testsigma/service/TestStepService.java
@@ -162,7 +162,7 @@ public class TestStepService extends XMLExportImportService<TestStep> {
     }
 
 
-    public TestStep create(TestStep testStep, Boolean isRecorderRequest) throws TestsigmaException,ResourceNotFoundException{
+    public TestStep create(TestStep testStep) throws TestsigmaException,ResourceNotFoundException{
         if(testStep.getAction()!=null
                 && testStep.getConditionType() == TestStepConditionType.LOOP_WHILE
                 &&(testStep.getMaxIterations() != null && (testStep.getMaxIterations() > 100))){
@@ -172,9 +172,7 @@ public class TestStepService extends XMLExportImportService<TestStep> {
         this.repository.incrementPosition(testStep.getPosition(), testStep.getTestCaseId());
         RestStep restStep = testStep.getRestStep();
         testStep.setRestStep(null);
-        if(isRecorderRequest) {
-            testStep = this.handleWhileTestStepCreate(testStep);
-        }
+        testStep = this.handleWhileTestStepCreate(testStep);
         testStep = this.repository.save(testStep);
         if (restStep != null) {
             RestStep newRestStep = mapper.mapStep(restStep);

--- a/server/src/main/java/com/testsigma/service/TestStepService.java
+++ b/server/src/main/java/com/testsigma/service/TestStepService.java
@@ -207,7 +207,7 @@ public class TestStepService extends XMLExportImportService<TestStep> {
             TestStepDataMap parentWhileStepMap = new TestStepDataMap();
             parentWhileStepMap.setWhileCondition("");
             parentWhileStep.setDataMap(parentWhileStepMap);
-            parentWhileStep = create(parentWhileStep, true);
+            parentWhileStep = create(parentWhileStep);
             testStep.setParentStep(parentWhileStep);
             testStep.setParentId(parentWhileStep.getId());
             testStep.setPosition(parentWhileStep.getPosition()+1);

--- a/ui/src/app/components/webcomponents/action-step-form.component.ts
+++ b/ui/src/app/components/webcomponents/action-step-form.component.ts
@@ -535,16 +535,12 @@ export class ActionStepFormComponent extends BaseComponent implements OnInit {
   }
 
   save(isSkip?: boolean) {
-    if (this.testStep.isConditionalWhileLoop && !isSkip) {
-      this.createWhileStep();
-    } else {
       this.formSubmitted = true;
       if (this.validation()) {
         this.saving = true;
         this.testStepService.create(this.testStep).subscribe(step => this.afterSave(step), e => this.handleSaveFailure(e));
       }
     }
-  }
 
   validateTestData() {
    if ((this.currentAddonTemplate || this.currentTemplate)&& this.navigateTemplate.includes(this.currentTemplate?.id))


### PR DESCRIPTION
# Description
* initially when while loop is created two post network call was created for while loop.
* one is a wrapper test step and another is the actual while test step

# Changes
* Due to new v2 Recorder, it creates only one post network call which contains the actual while test step and the wrapper test step is created in testStepService.
* To make this generalised for both recorder test step and normal test step, now there will only one network call will be created
* In testStepService, the function for recorder needs to be called for all cases.

# TODO
* in testStepService, the handleWhileTestStepCreate function is now only called for recorder while test step. it needs to be changed to all test steps. 