### PR TITLE
[TOS-254] fix(list.component) : Changing the text for empty trash testCase/stepGroup list

### DIFF
--- a/ui/src/app/components/cases/list.component.html
+++ b/ui/src/app/components/cases/list.component.html
@@ -213,7 +213,7 @@
           <div class="empty-run-md"></div>
           <div
             class="empty-text"
-            [translate]="!!query ? 'message.common.search.not_found' : 'testcase.list.not_found' | translate : { categoryType: isStepGroup? 'Step Groups' : 'Test Cases',type: isDeletedFilter? 'added to Trash': 'created'}"></div>
+            [translate]="!!query ? 'message.common.search.not_found' : 'testcase.list.not_found' | translate : { categoryType: isStepGroup? 'Step Groups' : 'Test Cases',type: isDeletedFilter? 'added to trash': 'created'}"></div>
           <div *ngIf="!!!query && currentFilter?.isAllCases">
             <a
               [routerLink]="['/td', versionId, isStepGroup? 'step_groups':'cases', 'create']" [queryParams]="{ isGroup: isStepGroup}"

--- a/ui/src/app/components/cases/list.component.html
+++ b/ui/src/app/components/cases/list.component.html
@@ -213,7 +213,7 @@
           <div class="empty-run-md"></div>
           <div
             class="empty-text"
-            [translate]="!!query ? 'message.common.search.not_found' : 'testcase.list.not_found' | translate : { categoryType: isStepGroup? 'Step Groups' : 'Test Cases'}"></div>
+            [translate]="!!query ? 'message.common.search.not_found' : 'testcase.list.not_found' | translate : { categoryType: isStepGroup? 'Step Groups' : 'Test Cases',type: isDeletedFilter? 'added to Trash': 'created'}"></div>
           <div *ngIf="!!!query && currentFilter?.isAllCases">
             <a
               [routerLink]="['/td', versionId, isStepGroup? 'step_groups':'cases', 'create']" [queryParams]="{ isGroup: isStepGroup}"

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -1014,7 +1014,7 @@
   "testcase.details.step_create_group": "{{Name}} Step Group",
   "testcase.details.step_bulk_update": "Bulk Update",
   "testcase.details.step_group.no_test_case": "No Test Case uses this Step Group.",
-  "testcase.list.not_found": "No {{categoryType}} created yet",
+  "testcase.list.not_found": "No {{categoryType}} {{type}} yet",
   "test_step.max_wait_time.info": "< 120 seconds",
   "test_step.max_wait_time.error": "Enter valid wait time between 1 to 120 seconds",
   "test_step.max_iterations.error": "Enter valid maximum iterations (1 to 100)",


### PR DESCRIPTION
* Jira: https://testsigma.atlassian.net/browse/TOS-254
# Description
Inappropriate message displayed when no Testcases/Step Groups are present in Trash 
* Actual
“No Step Groups created yet/No Test cases created yet” Message is displayed to user
* Expected
“No Test cases/Step groups added to Trash yet”
# Fix
made the appropriate changes in list.component.html and en.json