### PR TITLE
[TOS-968] fix(lab-environments-info) : added support for OS icon in test plan page

### DIFF
--- a/ui/src/app/components/webcomponents/lab-environments-info.component.ts
+++ b/ui/src/app/components/webcomponents/lab-environments-info.component.ts
@@ -27,10 +27,16 @@ import {TestDevice} from "../../models/test-device.model";
                 [class.testsigma-lab-logo]="env.isTestsigmaLab"
                 [class.testsigma-local-devices-logo]="env.isHybrid"
                 [matTooltip]="('execution.lab_type.'+env.testPlanLabType) | translate"></span>
+           <span
+             [matTooltip]="
+            (env?.platform ? ('platform.name.'+env?.platform | translate) : '') +
+            ((env?.platform && env?.osVersion)? '( '+ env?.osVersion+' ) ' : ' ')"
+             class="mr-5 fz-18 text-t-secondary"
+             [class.fa-windows-brands]="env?.isWindows"
+             [class.fa-apple]="env?.isMac"
+             [class.fa-linux-2]="env.isLinux"></span>
           <span
             [matTooltip]="
-            (env?.platform ? ('platform.name.'+env?.platform | translate) : '') +
-            ((env?.platform && env?.osVersion)? '( '+ env?.osVersion+' ) ' : ' ') +
             (env?.browser? ('browser.name.'+env?.browser | translate) : env?.deviceName) +
             (env?.browserVersion ? '( '+env?.browserVersion+' )' : '')"
             class="mr-5 fz-18 text-t-secondary"

--- a/ui/src/app/components/webcomponents/lab-environments-info.component.ts
+++ b/ui/src/app/components/webcomponents/lab-environments-info.component.ts
@@ -37,7 +37,7 @@ import {TestDevice} from "../../models/test-device.model";
              [class.fa-linux-2]="env.isLinux"></span>
           <span
             [matTooltip]="
-            (env?.browser? ('browser.name.'+env?.browser | translate) : env?.deviceName) +
+            (env?.browser=='MOZILLAFIREFOX'? ('browser.name.FIREFOX' | translate):env?.browser?('browser.name.'+env?.browser | translate) : env?.deviceName) +
             (env?.browserVersion ? '( '+env?.browserVersion+' )' : '')"
             class="mr-5 fz-18 text-t-secondary"
             [class.fa-chrome]="env?.isChrome"

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -488,7 +488,6 @@
   "platform.name.iOS": "iOS",
   "browser.name.GOOGLECHROME": "Google Chrome",
   "browser.name.CHROME": "Chrome",
-  "browser.name.MOZILLAFIREFOX": "Mozilla Firefox",
   "browser.name.FIREFOX" : "Mozilla Firefox",
   "browser.name.SAFARI": "Safari",
   "browser.name.EDGE": "Edge",

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -489,6 +489,7 @@
   "browser.name.GOOGLECHROME": "Google Chrome",
   "browser.name.CHROME": "Chrome",
   "browser.name.MOZILLAFIREFOX": "Mozilla Firefox",
+  "browser.name.FIREFOX" : "Mozilla Firefox",
   "browser.name.SAFARI": "Safari",
   "browser.name.EDGE": "Edge",
   "browser.name.INTERNETEXPLORER": "Internet Explorer",

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -488,7 +488,7 @@
   "platform.name.iOS": "iOS",
   "browser.name.GOOGLECHROME": "Google Chrome",
   "browser.name.CHROME": "Chrome",
-  "browser.name.FIREFOX": "Mozilla Firefox",
+  "browser.name.MOZILLAFIREFOX": "Mozilla Firefox",
   "browser.name.SAFARI": "Safari",
   "browser.name.EDGE": "Edge",
   "browser.name.INTERNETEXPLORER": "Internet Explorer",

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -488,7 +488,7 @@
   "platform.name.iOS": "iOS",
   "browser.name.GOOGLECHROME": "Google Chrome",
   "browser.name.CHROME": "Chrome",
-  "browser.name.FIREFOX" : "Mozilla Firefox",
+  "browser.name.FIREFOX": "Mozilla Firefox",
   "browser.name.SAFARI": "Safari",
   "browser.name.EDGE": "Edge",
   "browser.name.INTERNETEXPLORER": "Internet Explorer",


### PR DESCRIPTION
# Description
* Jira: https://testsigma.atlassian.net/browse/TOS-968
* Github Issue: https://github.com/testsigmahq/testsigma/issues/229
[Bug]: Operation System details shows under the Browser details icon in Test Lab Type
* What is the current behavior?
The Operating system details shows in Browser details icon in the Test Plan under Test Lab Type
Operating system details icon is missing
* What is the expected behavior?
Operating System details should display in separate icon
# Fix
added a span tag containing the respective os version and the respective os icon
![image](https://user-images.githubusercontent.com/106724526/220037426-e2310922-610c-4f8b-9483-536ed3f1143c.png)
* Note:
The webpage is loading very slow, not sure why