### PR TITLE
[TOS-1054] fix(dry-run-form) : fixed run button validation

### DIFF
--- a/ui/src/app/components/webcomponents/dry-run-form.component.html
+++ b/ui/src/app/components/webcomponents/dry-run-form.component.html
@@ -144,7 +144,7 @@
       [translate]="'btn.common.cancel'" mat-dialog-close>
     </button>
     <button
-      [disabled]="false && disableRunButton()"
+      [disabled]="disableRunButton()"
       (click)="save()"
       class="theme-btn-primary"
       [isLoading]="saving"

--- a/ui/src/app/components/webcomponents/dry-run-form.component.ts
+++ b/ui/src/app/components/webcomponents/dry-run-form.component.ts
@@ -405,7 +405,10 @@ export class DryRunFormComponent extends BaseComponent implements OnInit {
   }
 
   disableRunButton() {
-    return this.saving || this.savingConfig || this.emptyElements.length > 0 || !this.dryExecutionForm?.valid
+    if(this.isHybrid && this.dryExecutionForm.value.testDevices[0].platform==null)
+      return false
+    else
+      return this.saving || this.savingConfig || this.emptyElements.length > 0 || this.dryExecutionForm?.invalid
       || (!this.isHybrid && this.invalidUrls.length > 0) || (this.isHybrid && this.zeroActiveAgents);
   }
 

--- a/ui/src/app/components/webcomponents/dry-run-form.component.ts
+++ b/ui/src/app/components/webcomponents/dry-run-form.component.ts
@@ -405,7 +405,7 @@ export class DryRunFormComponent extends BaseComponent implements OnInit {
   }
 
   disableRunButton() {
-    if(this.isHybrid && this.dryExecutionForm.value.testDevices[0].platform==null)
+    if(this.isHybrid && this.dryExecutionForm?.value?.testDevices[0]?.platform==null)
       return false
     else
       return this.saving || this.savingConfig || this.emptyElements.length > 0 || this.dryExecutionForm?.invalid


### PR DESCRIPTION
# Description
* Jira: https://testsigma.atlassian.net/browse/TOS-1054
Run now button should be disabled state until the all fields load
* Actual
Now run now button its enabled state when we click on run now button its throwing a error 
* Expected
Run now button should be disabled state until the all fields load
# Fix
Removed the hardcoded false and altered the condition for local execution as  value for platform is undefined for local devices.