### PR TITLE
[TOS-336] fix(UploadFileAction): removing '\' in temp dir path

### DIFF
--- a/automator/src/com/testsigma/automator/actions/web/generic/UploadFileAction.java
+++ b/automator/src/com/testsigma/automator/actions/web/generic/UploadFileAction.java
@@ -15,7 +15,7 @@ public class UploadFileAction extends ElementAction {
     findElement();
     String downloadURL = getTestDataPropertiesEntity(TEST_STEP_DATA_MAP_KEY_TEST_DATA).getTestDataValuePreSignedURL();
     String fileName = String.format("%s_%s", System.currentTimeMillis(), FilenameUtils.getName(new URL(downloadURL).getPath()));
-    String filePath = String.format("%s%s%s", FileUtils.getTempDirectoryPath().endsWith("\\")?FileUtils.getTempDirectoryPath().substring(0,FileUtils.getTempDirectoryPath().length()-1):FileUtils.getTempDirectoryPath(), File.separator, fileName);
+    String filePath = String.format("%s%s%s", FileUtils.getTempDirectoryPath().endsWith(File.separator)?FileUtils.getTempDirectoryPath().substring(0,FileUtils.getTempDirectoryPath().length()-1):FileUtils.getTempDirectoryPath(), File.separator, fileName);
     FileUtils.copyURLToFile(new URL(downloadURL), new File(filePath), (60* 1000), (60 * 1000));
     getElement().sendKeys(filePath);
     setSuccessMessage("Successfully executed.");

--- a/automator/src/com/testsigma/automator/actions/web/generic/UploadFileAction.java
+++ b/automator/src/com/testsigma/automator/actions/web/generic/UploadFileAction.java
@@ -15,7 +15,7 @@ public class UploadFileAction extends ElementAction {
     findElement();
     String downloadURL = getTestDataPropertiesEntity(TEST_STEP_DATA_MAP_KEY_TEST_DATA).getTestDataValuePreSignedURL();
     String fileName = String.format("%s_%s", System.currentTimeMillis(), FilenameUtils.getName(new URL(downloadURL).getPath()));
-    String filePath = String.format("%s%s%s", FileUtils.getTempDirectoryPath(), File.separator, fileName);
+    String filePath = String.format("%s%s%s", FileUtils.getTempDirectoryPath().endsWith("\\")?FileUtils.getTempDirectoryPath().substring(0,FileUtils.getTempDirectoryPath().length()-1):FileUtils.getTempDirectoryPath(), File.separator, fileName);
     FileUtils.copyURLToFile(new URL(downloadURL), new File(filePath), (60* 1000), (60 * 1000));
     getElement().sendKeys(filePath);
     setSuccessMessage("Successfully executed.");

--- a/automator/src/com/testsigma/automator/actions/web/generic/UploadFileAction.java
+++ b/automator/src/com/testsigma/automator/actions/web/generic/UploadFileAction.java
@@ -15,7 +15,8 @@ public class UploadFileAction extends ElementAction {
     findElement();
     String downloadURL = getTestDataPropertiesEntity(TEST_STEP_DATA_MAP_KEY_TEST_DATA).getTestDataValuePreSignedURL();
     String fileName = String.format("%s_%s", System.currentTimeMillis(), FilenameUtils.getName(new URL(downloadURL).getPath()));
-    String filePath = String.format("%s%s%s", FileUtils.getTempDirectoryPath().endsWith(File.separator)?FileUtils.getTempDirectoryPath().substring(0,FileUtils.getTempDirectoryPath().length()-1):FileUtils.getTempDirectoryPath(), File.separator, fileName);
+    String tempDir = FileUtils.getTempDirectoryPath();
+    String filePath = String.format("%s%s%s", tempDir.endsWith(File.separator)?tempDir.substring(0,tempDir.length()-1):tempDir, File.separator, fileName);
     FileUtils.copyURLToFile(new URL(downloadURL), new File(filePath), (60* 1000), (60 * 1000));
     getElement().sendKeys(filePath);
     setSuccessMessage("Successfully executed.");


### PR DESCRIPTION
# Description
* Jira: https://testsigma.atlassian.net/browse/TOS-336
Not able to upload in Mobile web application using Nlp
* Actual
“Unable to perform specified action on current page - Appium error: An unknown server-side error occurred while processing the command. Original error: unknown error: path is not absolute: C:\Users\samisaac\AppData\Local\Temp\\1648903188621_Screenshot_(1).png (Session info: chrome=96.0.4664.104)” Message is displayed to user
* Expected
Should execute Upload Test step and img has to be uploaded
# Fix
problem was that the temp path had two '\' which made it invalid.
added a condition to check whether the temp path ends with '\' and removed it if present.