### PR TITLE
[TOS-969] fix: Browser name does not display on Local Devices selections.

### DIFF
--- a/ui/src/app/components/webcomponents/test-plan-platform-os-version-form.component.ts
+++ b/ui/src/app/components/webcomponents/test-plan-platform-os-version-form.component.ts
@@ -154,29 +154,31 @@ export class TestPlanPlatformOsVersionFormComponent implements OnInit {
   fetchBrowsers(setValue?: Boolean) {
     this.platformService.findAllBrowsers(this.platform, this.platformOsVersion, this.version.workspace.workspaceType, this.testPlanLabType).subscribe(res => {
       this.browsers = res;
-      if (!this.isPrivateGrid) {
-        if (this.environmentFormGroup?.controls['browser']?.value){
-          this.platformBrowser = this.browsers.find(browser => browser.id == this.environmentFormGroup?.controls['browser']?.value);
-        }
-        if (!this.platformBrowser || setValue) {
-          this.platformBrowser = this.browsers[0];
-          this.environmentFormGroup?.controls['browser']?.setValue(this.platformBrowser?.id);
-          if (this.version.workspace.isMobileWeb && this.platformBrowser.isChrome) {
-            this.environmentFormGroup?.controls['browser']?.setValue(WebBrowser.CHROME);
+      if(!this.isHybrid){
+        if (!this.isPrivateGrid) {
+          if (this.environmentFormGroup?.controls['browser']?.value){
+            this.platformBrowser = this.browsers.find(browser => browser.id == this.environmentFormGroup?.controls['browser']?.value);
+          }
+          if (!this.platformBrowser || setValue) {
+            this.platformBrowser = this.browsers[0];
+            this.environmentFormGroup?.controls['browser']?.setValue(this.platformBrowser?.id);
+            if (this.version.workspace.isMobileWeb && this.platformBrowser.isChrome) {
+              this.environmentFormGroup?.controls['browser']?.setValue(WebBrowser.CHROME);
+            }
           }
         }
-      }
-      if (this.isPrivateGrid) {
-        if (this.environmentFormGroup?.controls['browser']?.value)
-          this.platformBrowser = this.browsers.find(browser => browser.name == this.environmentFormGroup?.controls['browser']?.value);
-        if (!this.platformBrowser || setValue) {
-          this.platformBrowser = this.browsers[0];
-          this.environmentFormGroup?.controls['browser']?.setValue(this.platformBrowser?.name);
+        if (this.isPrivateGrid) {
+          if (this.environmentFormGroup?.controls['browser']?.value)
+            this.platformBrowser = this.browsers.find(browser => browser.name == this.environmentFormGroup?.controls['browser']?.value);
+          if (!this.platformBrowser || setValue) {
+            this.platformBrowser = this.browsers[0];
+            this.environmentFormGroup?.controls['browser']?.setValue(this.platformBrowser?.name);
 
+          }
         }
+        if (this.platformBrowser)
+          this.fetchBrowserVersions(setValue);
       }
-      if (this.platformBrowser)
-        this.fetchBrowserVersions(setValue);
     })
   }
 

--- a/ui/src/app/components/webcomponents/test-plan-test-machine-form.component.ts
+++ b/ui/src/app/components/webcomponents/test-plan-test-machine-form.component.ts
@@ -34,7 +34,6 @@ export class TestPlanTestMachineFormComponent extends TestPlanPlatformOsVersionF
     }
     if(this.isHybrid){
       this.setTargetMachines();
-      this.fetchPlatForms();
     }
   }
 


### PR DESCRIPTION
**Jira Ticket**:  https://testsigma.atlassian.net/browse/TOS-969

Actual:
-  When we select the Local Devices in Web to run options in ad-hoc runner, the Browser Name is not shown sometimes/ disappears in few seconds.
- Issue exists in Mac OS and Windows OS. Works fine in Linux. 

Expected: 
- The default set browser name must be displayed correctly, and must not disappear when shifting between Testsigma Lab and Local Devices tab in Ad-hoc Run Page.

Fix:
- Removed the call to fetchPlatforms() function if Hybrid -- Local Executions.
-  Added a 'IF' check to fetchBrowsers() function for Hybrid executions.
