### PR TITLE
[TOS-774]fix: Element details are not displayed properly in Dry Runs.

### DIFF
--- a/ui/src/app/components/webcomponents/action-step-result-details.component.ts
+++ b/ui/src/app/components/webcomponents/action-step-result-details.component.ts
@@ -130,8 +130,7 @@ export class ActionStepResultDetailsComponent extends BaseComponent implements O
   }
 
   getElementDetails() {
-    if (!this.ElementDetails)
-      this.ElementDetails = this.getElements(this.testStepResult?.elementDetails, true);
+    this.ElementDetails = this.getElements(this.testStepResult?.elementDetails, true);
     return this.ElementDetails.length || this.element?.locatorValue;//TODO Fallback element details need to clean
   }
 


### PR DESCRIPTION
Jira: https://testsigma.atlassian.net/browse/TOS-774

**Actual**
-In dry runs, the details of the first viewed element are displayed for all other elements.

**Expected**
-For each element used in each test step, the specific element’s details should be displayed.

Fix: Removed the existing if condition, which allows the element details corresponding to the selected test step to be displayed. The code earlier had an **if (!this.ElementDetails)**, which gets populated for the first step alone and then never becomes empty, thus displaying the first element details for all steps irrespective of their element details.