### PR TITLE
fix:[TOS-985] - Step Group Creation from Test Case does not redirect to created step group.

### DIFF
--- a/ui/src/app/components/webcomponents/create-test-group-from-step-form.component.ts
+++ b/ui/src/app/components/webcomponents/create-test-group-from-step-form.component.ts
@@ -85,9 +85,9 @@ export class CreateTestGroupFromStepFormComponent extends BaseComponent implemen
       setTimeout(() => this.searchInput.nativeElement.focus(), 200);
     })
   }
+
   navigateToCase(testCaseId: number){
     window.open('td/cases/'+testCaseId.toString(), '_blank');
-
   }
 
   saveAsStepGroup(isReplace?: boolean) {

--- a/ui/src/app/components/webcomponents/create-test-group-from-step-form.component.ts
+++ b/ui/src/app/components/webcomponents/create-test-group-from-step-form.component.ts
@@ -11,6 +11,7 @@ import {TranslateService} from '@ngx-translate/core';
 import {ToastrService} from "ngx-toastr";
 import {TestStepService} from "../../services/test-step.service";
 import {TestStepConditionType} from "../../enums/test-step-condition-type.enum";
+import {Router} from "@angular/router";
 
 @Component({
   selector: 'app-copy-test-case',
@@ -23,6 +24,7 @@ export class CreateTestGroupFromStepFormComponent extends BaseComponent implemen
   @ViewChild('nameInput') searchInput: ElementRef;
 
   constructor(
+    public router: Router,
     private dialogRef: MatDialogRef<CreateTestGroupFromStepFormComponent>,
     @Inject(MAT_DIALOG_DATA) public options: {
       testCase: TestCase,
@@ -84,6 +86,10 @@ export class CreateTestGroupFromStepFormComponent extends BaseComponent implemen
       setTimeout(() => this.searchInput.nativeElement.focus(), 200);
     })
   }
+  navigateToCase(testCaseId: number){
+    window.open('td/cases/'+testCaseId.toString(), '_blank');
+
+  }
 
   saveAsStepGroup(isReplace?: boolean) {
     this.saving = true;
@@ -96,6 +102,7 @@ export class CreateTestGroupFromStepFormComponent extends BaseComponent implemen
     }
     this.testCaseService.copy(copyStepGroup).subscribe(
       (testCase) => {
+        this.navigateToCase(testCase.id)
         this.translate.get('test_step.copy_as.step_group.success').subscribe((res: string) => {
           this.showNotification(NotificationType.Success, res);
           this.dialogRef.close({testCase: testCase, isReplace: isReplace});

--- a/ui/src/app/components/webcomponents/create-test-group-from-step-form.component.ts
+++ b/ui/src/app/components/webcomponents/create-test-group-from-step-form.component.ts
@@ -11,7 +11,7 @@ import {TranslateService} from '@ngx-translate/core';
 import {ToastrService} from "ngx-toastr";
 import {TestStepService} from "../../services/test-step.service";
 import {TestStepConditionType} from "../../enums/test-step-condition-type.enum";
-import {Router} from "@angular/router";
+
 
 @Component({
   selector: 'app-copy-test-case',
@@ -24,7 +24,6 @@ export class CreateTestGroupFromStepFormComponent extends BaseComponent implemen
   @ViewChild('nameInput') searchInput: ElementRef;
 
   constructor(
-    public router: Router,
     private dialogRef: MatDialogRef<CreateTestGroupFromStepFormComponent>,
     @Inject(MAT_DIALOG_DATA) public options: {
       testCase: TestCase,


### PR DESCRIPTION
JIRA: https://testsigma.atlassian.net/browse/TOS-985

**Description**
When the user creates a step group by selecting test steps in a test case, after clicking on the create button, the page does not redirect to the created step group.

**Actual**
After creation of step group by selecting test steps in a test case, the page does not redirect to created step group page.

**Expected**
After creation of step group by selecting test steps in a test case, the page should redirect to created step group page.

Fix: 
Added a function that gets called to redirect to the new window, containing the step group details.