### PR TITLE
[TOS-1044]Fix: Prerequisite step number displaying as NaN in Step res…

### DIFF
--- a/server/src/main/java/com/testsigma/dto/StepDetailsDTO.java
+++ b/server/src/main/java/com/testsigma/dto/StepDetailsDTO.java
@@ -21,6 +21,7 @@ public class StepDetailsDTO {
   private Long id;
   private String stepDescription;
   private TestStepPriority priority;
+  @JsonProperty("order_id")
   private Integer position;
   private Long preRequisiteStepId;
   private String action;

--- a/ui/src/app/components/webcomponents/action-step-result-details.component.ts
+++ b/ui/src/app/components/webcomponents/action-step-result-details.component.ts
@@ -149,7 +149,7 @@ export class ActionStepResultDetailsComponent extends BaseComponent implements O
   }
 
   get preRequisiteStep() {
-    return this.preRequestStep?.testStep?.stepDisplayNumber ? this.preRequestStep?.testStep?.stepDisplayNumber : (<number>this.preRequestStep?.stepDetail?.order_id + 1)
+    return this.preRequestStep?.testStep?.stepDisplayNumber ? this.preRequestStep?.testStep?.stepDisplayNumber : (<number>this.preRequestStep?.stepDetail?.order_id)
   }
 
   fetchElementByName(elementName, addonElement?) {


### PR DESCRIPTION
**JIRA:** https://testsigma.atlassian.net/browse/TOS-1044

**Actual**
Test case results in page step prerequisite field displaying as NaN 

**Expected**
it should show the prerequisite test step number

**Fix:**
Added a JsonProperty Annotation to map Order_id in the front end. Removed order_id +1 and changed to the correct step number[order_id] to display the right position.