### PR TITLE
[TOS-1093] (feat): Add support for IOS executions to run in local without idb installation

### DIFF
--- a/agent/src/main/java/com/testsigma/agent/mobile/ios/WdaService.java
+++ b/agent/src/main/java/com/testsigma/agent/mobile/ios/WdaService.java
@@ -12,6 +12,8 @@ import com.testsigma.automator.exceptions.AutomatorException;
 import com.testsigma.automator.http.HttpResponse;
 import com.testsigma.automator.mobile.ios.IosDeviceCommandExecutor;
 import com.testsigma.agent.utils.ZipUtil;
+
+import java.io.IOException;
 import java.nio.file.Files;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -36,11 +38,11 @@ public class WdaService {
   private static final String WDA_BUNDLE_ID = "com.facebook.WebDriverAgentRunner.xctrunner";
   private final AgentConfig agentConfig;
   private final WebAppHttpClient httpClient;
+  private final IosDeviceCommandExecutor iosDeviceCommandExecutor;
 
   public void installWdaToDevice(MobileDevice device) throws TestsigmaException {
     File downloadedWdaFile = null;
     try {
-      IosDeviceCommandExecutor iosDeviceCommandExecutor = new IosDeviceCommandExecutor();
       log.info("Installing WDA on device - " + device.getUniqueId());
       String wdaPresignedUrl = fetchWdaUrl(device);
       log.info("Wda presigned url: " + wdaPresignedUrl);
@@ -49,7 +51,7 @@ public class WdaService {
       log.info("Downloaded WDA to local file - " + downloadedWdaFile.getAbsolutePath());
       Process p;
       if(device.getIsEmulator()) {
-        p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"install", "--udid", device.getUniqueId(),
+        p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"install", device.getUniqueId(),
                 downloadedWdaFile.getAbsolutePath()}, false);
       } else {
         p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"-u", device.getUniqueId(), "install",
@@ -74,42 +76,20 @@ public class WdaService {
     }
   }
 
-  public void installXCTestToDevice(MobileDevice device) throws TestsigmaException {
+  private File downloadXCTestFile(MobileDevice device) throws Exception {
     File downloadedXCTestFile = null;
-    try {
-      IosDeviceCommandExecutor iosDeviceCommandExecutor = new IosDeviceCommandExecutor();
-      log.info("Installing XCTest on device - " + device.getUniqueId());
-      String xcTestRemotePath = fetchXcTestRunnerUrl(device);
-      File destFolder = Files.createTempDirectory("wda_xctest").toFile();
-      File unZippedFolder = ZipUtil.unZipFile(xcTestRemotePath, destFolder);
-      downloadedXCTestFile = new File(unZippedFolder.getAbsolutePath() + "/WebDriverAgentRunner.xctest");
-      log.info("Downloaded XCTest to local file - " + downloadedXCTestFile.getAbsolutePath());
-      Process p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"xctest", "install", downloadedXCTestFile.getAbsolutePath(),
-              "--udid", device.getUniqueId()}, false);
-      p.waitFor(20, TimeUnit.SECONDS);
-      String devicePropertiesJsonString = iosDeviceCommandExecutor.getProcessStreamResponse(p);
-      log.info("Output from installing XCTest file on the device - " + devicePropertiesJsonString);
-      if (p.exitValue() == 1) {
-        throw new TestsigmaException("Failed to install XCTest on device - " + device.getUniqueId());
-      }
-    } catch (Exception e) {
-      throw new TestsigmaException(e.getMessage(), e);
-    } finally {
-      if ((downloadedXCTestFile != null) && downloadedXCTestFile.exists()) {
-        boolean deleted = downloadedXCTestFile.delete();
-        if (!deleted) {
-          log.error("Error while deleting the downloaded xcTest directory - " + downloadedXCTestFile.getAbsolutePath());
-        }
-      }
-    }
+    String xcTestRemotePath = fetchXcTestRunnerUrl(device);
+    File destFolder = Files.createTempDirectory("wda_xctest").toFile();
+    File unZippedFolder = ZipUtil.unZipFile(xcTestRemotePath, destFolder);
+    downloadedXCTestFile = new File(unZippedFolder.getAbsolutePath() + "/WebDriverAgentRunner.xctest");
+    log.info("Downloaded XCTest to local file - " + downloadedXCTestFile.getAbsolutePath());
+    return downloadedXCTestFile;
   }
 
   public void startWdaOnDevice(MobileDevice device) throws TestsigmaException {
     try {
       log.info("Starting WDA on device - " + device.getName());
       log.info("Checking for any previously started WDA processes on device - " + device.getName());
-      IosDeviceCommandExecutor iosDeviceCommandExecutor = new IosDeviceCommandExecutor();
-
       stopWdaOnDevice(device);
       device.setWdaExecutorService(Executors.newSingleThreadExecutor());
       device.setWdaRelayExecutorService(Executors.newSingleThreadExecutor());
@@ -117,9 +97,11 @@ public class WdaService {
       device.getWdaExecutorService().execute(() -> {
         try {
           Process p;
+          String xcTestPath = null;
           if(device.getIsEmulator()) {
-            p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"launch", "--udid", device.getUniqueId(),
-                    WDA_BUNDLE_ID}, false);
+            xcTestPath = downloadXCTestFile(device).getAbsolutePath();
+            p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"launch", device.getUniqueId(),
+                    WDA_BUNDLE_ID, "-XCTest", "All", xcTestPath}, false);
           } else {
             p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"-u", device.getUniqueId(), "xctest",
                     "-B", WDA_BUNDLE_ID}, true);
@@ -158,7 +140,6 @@ public class WdaService {
   }
 
   private void checkWDAProcessStatus(MobileDevice device) throws TestsigmaException, AutomatorException, InterruptedException {
-    IosDeviceCommandExecutor iosDeviceCommandExecutor = new IosDeviceCommandExecutor();
     int retries = 3;
     while (device.getWdaProcess() == null && (device.getWdaProcess().isAlive() || device.getWdaProcess().exitValue() == 0) && retries-- > 0) {
       log.info("WDA process not started yet, waiting for 5 seconds...");
@@ -175,7 +156,6 @@ public class WdaService {
   }
 
   private void checkWDARelayProcessStatus(MobileDevice device) throws TestsigmaException, AutomatorException, InterruptedException {
-    IosDeviceCommandExecutor iosDeviceCommandExecutor = new IosDeviceCommandExecutor();
     int retries = 3;
     while (device.getWdaRelayProcess() == null && !device.getWdaRelayProcess().isAlive() && retries-- > 0) {
       log.info("WDA process not started yet, waiting for 5 seconds...");

--- a/automator/src/com/testsigma/automator/drivers/mobile/MobileDriver.java
+++ b/automator/src/com/testsigma/automator/drivers/mobile/MobileDriver.java
@@ -103,26 +103,15 @@ public class MobileDriver extends TestsigmaDriver {
         return false;
       }
       IosDeviceCommandExecutor iosDeviceCommandExecutor = new IosDeviceCommandExecutor();
-      Process p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"describe", "--udid", udid, "--json"}, false);
-      String deviceDescriptionJson = iosDeviceCommandExecutor.getProcessStreamResponse(p);
-      JSONObject device = getProperties(deviceDescriptionJson);
-      if (device.getString("target_type").equals("simulator")) {
+      Process p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"list", "devices", "available"}, false);
+      String deviceListOutput = iosDeviceCommandExecutor.getProcessStreamResponse(p);
+      String deviceLine = String.format("(%s) (Booted)", udid.toUpperCase());
+      if (deviceListOutput != null && deviceListOutput.contains(deviceLine)) {
         return true;
       }
     } catch(Exception e) {
       log.error(e.getMessage(), e);
     }
     return false;
-  }
-
-  private JSONObject getProperties(String deviceJson) throws TestsigmaException {
-    try {
-      log.info("Fetching device properties for device - " + deviceJson);
-      JSONObject devicePropertiesJson = new JSONObject(deviceJson);
-      log.info("Fetched device properties for device in json format - " + devicePropertiesJson);
-      return devicePropertiesJson;
-    } catch (Exception e) {
-      throw new TestsigmaException(e.getMessage());
-    }
   }
 }

--- a/automator/src/com/testsigma/automator/mobile/ios/AppInstaller.java
+++ b/automator/src/com/testsigma/automator/mobile/ios/AppInstaller.java
@@ -33,7 +33,7 @@ public class AppInstaller {
       appFile = downloadApp(appUrl);
       String bundleId = getAppBundleId(appFile);
       if(isEmulator) {
-        Process p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"install", "--udid", deviceUniqueId,
+        Process p = iosDeviceCommandExecutor.runDeviceCommand(new String[]{"install", deviceUniqueId,
                 appFile.getAbsolutePath()}, false);
         p.waitFor(30, TimeUnit.SECONDS);
         String devicePropertiesJsonString = iosDeviceCommandExecutor.getProcessStreamResponse(p);

--- a/automator/src/com/testsigma/automator/mobile/ios/IosDeviceCommandExecutor.java
+++ b/automator/src/com/testsigma/automator/mobile/ios/IosDeviceCommandExecutor.java
@@ -2,7 +2,6 @@ package com.testsigma.automator.mobile.ios;
 
 import com.testsigma.automator.exceptions.AutomatorException;
 import com.testsigma.automator.exceptions.TestsigmaException;
-import com.testsigma.automator.service.ObjectMapperService;
 import com.testsigma.automator.utilities.PathUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -22,7 +21,7 @@ import java.util.Arrays;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class IosDeviceCommandExecutor {
 
-  private static final String IDB_EXECUTABLE = "idb";
+  private static final String XCRUN_EXECUTABLE = "xcrun";
 
   public String getTiDeviceExecutablePath() {
     if (SystemUtils.IS_OS_WINDOWS) {
@@ -32,21 +31,21 @@ public class IosDeviceCommandExecutor {
     }
   }
 
-  public String getIdbExecutablePath() throws TestsigmaException {
+  public String getXrunExecutablePath() throws TestsigmaException {
     if (SystemUtils.IS_OS_WINDOWS) {
       throw new TestsigmaException("Idb is not supported for Windows platform");
     } else {
-      return IDB_EXECUTABLE;
+      return XCRUN_EXECUTABLE;
     }
   }
 
   public Process runDeviceCommand(String[] subCommand, Boolean executeWithTiDevice) throws AutomatorException {
     try {
-      String iosDeviceExecutablePath = getIdbExecutablePath();
+      String[] iosDeviceExecutablePath = new String[]{getXrunExecutablePath(), "simctl"};
       if(executeWithTiDevice) {
-        iosDeviceExecutablePath = getTiDeviceExecutablePath();
+        iosDeviceExecutablePath = new String[]{getTiDeviceExecutablePath()};
       }
-      String[] command = ArrayUtils.addAll(new String[]{iosDeviceExecutablePath}, subCommand);
+      String[] command = ArrayUtils.addAll(iosDeviceExecutablePath, subCommand);
 
       log.debug("Running the command - " + Arrays.toString(command));
 

--- a/server/src/main/java/com/testsigma/controller/recorder/TestStepsRecorderController.java
+++ b/server/src/main/java/com/testsigma/controller/recorder/TestStepsRecorderController.java
@@ -1,6 +1,5 @@
 package com.testsigma.controller.recorder;
 
-import com.testsigma.dto.ForLoopConditionDTO;
 import com.testsigma.dto.RestStepResponseDTO;
 import com.testsigma.dto.TestStepDTO;
 import com.testsigma.exception.ResourceNotFoundException;
@@ -45,7 +44,6 @@ public class TestStepsRecorderController {
     private final TestStepService service;
     private final TestStepMapper mapper;
     private final ElementService elementService;
-    //private final ElementMapper elementMapper;
     private final UiIdentifierMapper uiIdentifierMapper;
     private final TestStepRecorderMapper testStepRecorderMapper;
     private final ForLoopConditionService forLoopConditionsService;


### PR DESCRIPTION
Background: 
Currently, a user needs to install idb to run executions on IOS emulators. We want to move away from idb to xcrun so that users don’t require any installations.

https://testsigma.atlassian.net/browse/TOS-1093
