### PR TITLE
[TOS-1044] fix: Prerequisite Step number displayed as NaN

### DIFF
--- a/server/src/main/java/com/testsigma/dto/StepDetailsDTO.java
+++ b/server/src/main/java/com/testsigma/dto/StepDetailsDTO.java
@@ -21,7 +21,6 @@ public class StepDetailsDTO {
   private Long id;
   private String stepDescription;
   private TestStepPriority priority;
-  @JsonProperty("order_id")
   private Integer position;
   private Long preRequisiteStepId;
   private String action;

--- a/server/src/main/java/com/testsigma/dto/StepDetailsDTO.java
+++ b/server/src/main/java/com/testsigma/dto/StepDetailsDTO.java
@@ -21,6 +21,7 @@ public class StepDetailsDTO {
   private Long id;
   private String stepDescription;
   private TestStepPriority priority;
+  @JsonProperty("order_id")
   private Integer position;
   private Long preRequisiteStepId;
   private String action;

--- a/ui/src/app/components/webcomponents/action-step-result-details.component.ts
+++ b/ui/src/app/components/webcomponents/action-step-result-details.component.ts
@@ -149,7 +149,7 @@ export class ActionStepResultDetailsComponent extends BaseComponent implements O
   }
 
   get preRequisiteStep() {
-    return this.preRequestStep?.testStep?.stepDisplayNumber ? this.preRequestStep?.testStep?.stepDisplayNumber : (<number>this.preRequestStep?.stepDetail?.order_id + 1)
+    return this.preRequestStep?.testStep?.stepDisplayNumber ? this.preRequestStep?.testStep?.stepDisplayNumber : (<number>this.preRequestStep?.stepDetail?.order_id)
   }
 
   fetchElementByName(elementName, addonElement?) {

--- a/ui/src/app/models/step-details.model.ts
+++ b/ui/src/app/models/step-details.model.ts
@@ -19,7 +19,7 @@ export class StepDetails extends Base implements Deserializable {
   public conditionType: TestStepConditionType;
   @serializable
   public action: String;
-  @serializable
+  @serializable(alias('position', custom(() => SKIP, (v) => v)))
   public order_id: Number;
   @serializable
   public priority: TestStepPriority;


### PR DESCRIPTION
**Actual**
Test case results in page step prerequisite field displaying as NaN 

**Expected**
it should show the prerequisite test step number
 

Fix:  
De-serialized the order_id property in the front end by alias-ing with position in the step details model.
Removed the annotation from the backend in Step Details DTO, as that fix was not working. Retained the removal of +1 to display the correct step order of the pre-requisite, which otherwise displays the position+1 of the pre-requisite step.