### PR TITLE
Fixed issue with uiAutomator2-driver

### DIFF
--- a/agent/src/main/resources/agent.properties
+++ b/agent/src/main/resources/agent.properties
@@ -9,4 +9,4 @@
 cloud.url=${CLOUD_URL:https://local.testsigmaos.com}
 local.server.url=${LOCAL_SERVER_URL:http://localhost:9090}
 local.agent.register=${LOCAL_AGENT_REGISTER:true}
-agent.version=3.0.0
+agent.version=3.0.1

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       interval: 1s
       retries: 120
   testsigma_server:
-    image: testsigmahq/server:v3.0.0 # Replace with testsigmahq/server:v3.0.0-m1 for m1
+    image: testsigmahq/server:v3.0.1 # Replace with testsigmahq/server:v3.0.1-m1 for m1
     container_name: testsigma_server
     ports:
       - "9090:9090"

--- a/server/src/main/java/com/testsigma/dto/AgentDTO.java
+++ b/server/src/main/java/com/testsigma/dto/AgentDTO.java
@@ -30,5 +30,5 @@ public class AgentDTO {
   private String hostName;
   private AgentOs osType;
   private String osVersion;
-  private String currentAgentVersion = "3.0.0";
+  private String currentAgentVersion = "3.0.1";
 }


### PR DESCRIPTION
## Description

In the mac agent, the uiAutomator2-driver zip is missing and because of that, android executions are not possible

Fixes # (issue)

- Added uiAutomator2-driver.zip in s3
- Bumped version to 3.0.1

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Changes would cause existing functionality to not work as expected
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
