### PR TITLE
[TE-11836]: Webdrivermanager and version upgrade

### DIFF
--- a/agent/src/main/resources/agent.properties
+++ b/agent/src/main/resources/agent.properties
@@ -9,4 +9,4 @@
 cloud.url=${CLOUD_URL:https://local.testsigmaos.com}
 local.server.url=${LOCAL_SERVER_URL:http://localhost:9090}
 local.agent.register=${LOCAL_AGENT_REGISTER:true}
-agent.version=3.0.0
+agent.version=3.0.1

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       interval: 1s
       retries: 120
   testsigma_server:
-    image: testsigmahq/server:v3.0.0 # Replace with testsigmahq/server:v3.0.0-m1 for m1
+    image: testsigmahq/server:v3.0.1 # Replace with testsigmahq/server:v3.0.1-m1 for m1
     container_name: testsigma_server
     ports:
       - "9090:9090"

--- a/server/src/main/java/com/testsigma/dto/AgentDTO.java
+++ b/server/src/main/java/com/testsigma/dto/AgentDTO.java
@@ -30,5 +30,5 @@ public class AgentDTO {
   private String hostName;
   private AgentOs osType;
   private String osVersion;
-  private String currentAgentVersion = "3.0.0";
+  private String currentAgentVersion = "3.0.1";
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=${TESTSIGMA_SERVER_PORT:9090}
 server.url=${TESTSIGMA_SERVER_URL:https://local.testsigmaos.com}
-server.version=v3.0.0
+server.version=v3.0.1
 server.local.url=${TESTSIGMA_SERVER_LOCAL_URL:http://localhost:${server.port}}
 local.agent.url=${LOCAL_AGENT_URL:http://localhost:9393/agent}
 local.agent.download.tag=latest


### PR DESCRIPTION
The chromedriver team has stopped publishing the chromedriver releases and metadata using their traditional [chromedriver download repository](https://chromedriver.chromium.org/downloads) with chromedriver 114. This way, as of chromedriver 115, the chromedriver releases can only be discovered programmatically using the [Chrome for Testing (CfT) JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints).

This change is very relevant for WebDriverManager, since, as of Chrome 115 and 116, chromedriver cannot be managed automatically by WebDriverManager using the traditional way. Therefore, for older versions of WebDriverManager, this situation led to errors like the following:

io.github.bonigarcia.wdm.online.HttpClient: Error HTTP 404 executing https://chromedriver.storage.googleapis.com/LATEST_RELEASE_116 org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114

WebDriverManager 5.4+ implements the support for the CfT endpoints. Therefore, the solution to this problem is to bump WebDriverManager to the latest version (5.4.1 currently)