### PR TITLE
Check for null value with the appropriate assertion method

### DIFF
--- a/automator/src/com/testsigma/automator/actions/web/verify/VerifyAlertPresentAction.java
+++ b/automator/src/com/testsigma/automator/actions/web/verify/VerifyAlertPresentAction.java
@@ -17,7 +17,7 @@ public class VerifyAlertPresentAction extends MobileElementAction {
   public void execute() throws Exception {
     WebDriverWait waiter = new WebDriverWait(getDriver(), Duration.ofSeconds(30));
     Alert alert = waiter.until(ExpectedConditions.alertIsPresent());
-    Assert.isTrue(alert != null, ALERT_VERIFICATION_FAILURE);
+    Assert.notNull(alert, ALERT_VERIFICATION_FAILURE);
     setSuccessMessage(SUCCESS_MESSAGE);
   }
 }


### PR DESCRIPTION
## Description

Replace all occurrences of `Assert.isTrue\((\w+)\s?!=\s?null\s*,` with `Assert.notNull($1,`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Changes would cause existing functionality to not work as expected
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
